### PR TITLE
Fix Pipedream Connect proxy header forwarding

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1174,6 +1174,22 @@ export class ASIConnectMCP extends McpAgent<Env, unknown, Props> {
 
 					pdToken = pdToken || (await getPdAccessToken(this.env));
 
+					// Process headers for Pipedream Connect proxy
+					// Pipedream Connect proxy only forwards headers with x-pd-proxy- prefix
+					let processedHeaders: Record<string, string> | undefined = undefined;
+					if (headers) {
+						processedHeaders = {};
+						for (const [key, value] of Object.entries(headers)) {
+							// Add x-pd-proxy- prefix to all custom headers so they get forwarded
+							if (!key.toLowerCase().startsWith('x-pd-proxy-')) {
+								processedHeaders[`x-pd-proxy-${key}`] = value;
+							} else {
+								// Already has prefix, keep as-is
+								processedHeaders[key] = value;
+							}
+						}
+					}
+
 					// Add nested span for the actual HTTP request (with fallback)
 					let result: any;
 					const executeProxyRequest = async () => {
@@ -1182,7 +1198,7 @@ export class ASIConnectMCP extends McpAgent<Env, unknown, Props> {
 							account_id: acctId,
 							method,
 							url,
-							headers,
+							headers: processedHeaders,
 							body: proxyBody,
 						});
 


### PR DESCRIPTION
## Summary

Fixes custom header forwarding issue in Pipedream Connect proxy that was causing 403 AuthenticationUnsuccessful errors for APIs requiring custom headers (e.g., Xero's `Xero-Tenant-Id` header).

## Root Cause

Pipedream Connect proxy only forwards headers that have the `x-pd-proxy-` prefix. Custom headers like `Xero-Tenant-Id`, `Authorization`, etc. were being dropped at the proxy boundary, never reaching the destination API.

## Solution

- Automatically add `x-pd-proxy-` prefix to all custom headers in the `proxy_request` tool
- Preserve headers that already have the prefix (idempotent operation)
- Universal fix that works for all APIs, not just Xero

## Before/After

**Before:**
```json
headers: {
  "Xero-Tenant-Id": "abc-123",
  "Accept": "application/json"
}
```
Result: Headers dropped → 403 AuthenticationUnsuccessful

**After:**
```json  
processedHeaders: {
  "x-pd-proxy-Xero-Tenant-Id": "abc-123",
  "x-pd-proxy-Accept": "application/json"  
}
```
Result: Headers forwarded → API calls succeed ✅

## Testing

- ✅ Verified Xero `/api.xro/2.0/organisations` endpoint now returns full XML response (8571 bytes)
- ✅ Tested with curl commands confirming header forwarding works correctly
- ✅ Backwards compatible - existing code continues to work

## Impact

Resolves issues with:
- Xero Accounting API endpoints (`/api.xro/2.0/*`)
- Any other API requiring custom headers through Pipedream Connect proxy
- Future-proofs against similar header forwarding issues

🤖 Generated with [Claude Code](https://claude.ai/code)