### PR TITLE
Fix search_apps to search all available Pipedream Connect apps

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -109,8 +109,8 @@ async function fetchProxyEnabledApps(
 		}
 	} catch {}
 
-	// Fetch from Pipedream REST API
-	const res = await fetch("https://api.pipedream.com/v1/apps", {
+	// Fetch from Pipedream Connect API to get all available apps
+	const res = await fetch("https://api.pipedream.com/v1/connect/apps", {
 		headers: {
 			Authorization: `Bearer ${pdToken}`,
 			"x-pd-environment": env.PIPEDREAM_ENV,
@@ -201,9 +201,9 @@ async function searchAppsWithCache(
 		} catch {}
 
 		if (!allApps) {
-			// Fetch from Pipedream REST API with error handling
+			// Fetch from Pipedream Connect API to get all available apps (not just project-specific)
 			try {
-				const res = await fetch("https://api.pipedream.com/v1/apps", {
+				const res = await fetch("https://api.pipedream.com/v1/connect/apps", {
 					headers: {
 						Authorization: `Bearer ${pdToken}`,
 						"x-pd-environment": env.PIPEDREAM_ENV,
@@ -1142,8 +1142,8 @@ ${connectedApps.length > 0
 				}) => {
 					const pdToken = await getPdAccessToken(this.env);
 					
-					// Fetch all available apps from Pipedream
-					const res = await fetch("https://api.pipedream.com/v1/apps", {
+					// Fetch all available apps from Pipedream Connect (not just project-specific apps)
+					const res = await fetch("https://api.pipedream.com/v1/connect/apps", {
 						headers: {
 							Authorization: `Bearer ${pdToken}`,
 							"x-pd-environment": this.env.PIPEDREAM_ENV,


### PR DESCRIPTION
## Summary

- Fix `search_apps` tool to search all available Pipedream Connect apps instead of only project-specific configured apps
- Change API endpoint from `/v1/apps` to `/v1/connect/apps` in three locations
- Now searches across all 2,800+ available integrations that Pipedream supports

## Problem

Previously, `search_apps` with queries like `"hubspot"` would return no results because it only searched apps already configured in the specific project environment. This was confusing for users who expected to find all available apps they could connect to.

## Solution

Updated the API endpoint from `/v1/apps` (project-specific) to `/v1/connect/apps` (all available apps) in:

1. Main `search_apps` tool implementation 
2. Cached `searchAppsWithCache` function  
3. `fetchProxyEnabledApps` function

## Test plan

- [x] TypeScript compilation passes
- [x] Code follows existing patterns
- [ ] Test search with `query: "hubspot"` - should now return HubSpot apps
- [ ] Test search with `query: "xero"` - should return Xero apps
- [ ] Verify search still works with existing queries like `description: "marketing"`

🤖 Generated with [Claude Code](https://claude.ai/code)