### PR TITLE
Add minimal success and failure pages for auth redirects

### DIFF
--- a/src/auth-failure.html
+++ b/src/auth-failure.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Connection Failed</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            background: linear-gradient(135deg, #ef4444 0%, #dc2626 100%);
+            margin: 0;
+            padding: 0;
+            height: 100vh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+        .container {
+            background: white;
+            padding: 2rem;
+            border-radius: 12px;
+            box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
+            text-align: center;
+            max-width: 400px;
+            margin: 20px;
+        }
+        .error-icon {
+            color: #ef4444;
+            font-size: 4rem;
+            margin-bottom: 1rem;
+        }
+        h1 {
+            color: #1f2937;
+            margin-bottom: 0.5rem;
+            font-size: 1.75rem;
+        }
+        p {
+            color: #6b7280;
+            margin-bottom: 2rem;
+            line-height: 1.5;
+        }
+        .close-btn {
+            background: #ef4444;
+            color: white;
+            border: none;
+            padding: 12px 24px;
+            border-radius: 6px;
+            font-size: 1rem;
+            cursor: pointer;
+            transition: background-color 0.2s;
+            margin-right: 10px;
+        }
+        .close-btn:hover {
+            background: #dc2626;
+        }
+        .retry-btn {
+            background: #6b7280;
+            color: white;
+            border: none;
+            padding: 12px 24px;
+            border-radius: 6px;
+            font-size: 1rem;
+            cursor: pointer;
+            transition: background-color 0.2s;
+        }
+        .retry-btn:hover {
+            background: #4b5563;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="error-icon">✗</div>
+        <h1>Connection Failed</h1>
+        <p>There was a problem connecting your account. Please try again or contact support if the issue persists.</p>
+        <button class="retry-btn" onclick="history.back()">Try Again</button>
+        <button class="close-btn" onclick="window.close()">Close Window</button>
+    </div>
+    
+    <script>
+        // Auto-close after 5 seconds if window.close() doesn't work (longer delay for error case)
+        setTimeout(() => {
+            try {
+                window.close();
+            } catch (e) {
+                // If close fails, show a message
+                document.querySelector('p').innerHTML = 'Connection failed. Please close this tab manually and try again.';
+            }
+        }, 5000);
+    </script>
+</body>
+</html>

--- a/src/auth-success.html
+++ b/src/auth-success.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Connection Successful</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            margin: 0;
+            padding: 0;
+            height: 100vh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+        .container {
+            background: white;
+            padding: 2rem;
+            border-radius: 12px;
+            box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
+            text-align: center;
+            max-width: 400px;
+            margin: 20px;
+        }
+        .success-icon {
+            color: #10b981;
+            font-size: 4rem;
+            margin-bottom: 1rem;
+        }
+        h1 {
+            color: #1f2937;
+            margin-bottom: 0.5rem;
+            font-size: 1.75rem;
+        }
+        p {
+            color: #6b7280;
+            margin-bottom: 2rem;
+            line-height: 1.5;
+        }
+        .close-btn {
+            background: #10b981;
+            color: white;
+            border: none;
+            padding: 12px 24px;
+            border-radius: 6px;
+            font-size: 1rem;
+            cursor: pointer;
+            transition: background-color 0.2s;
+        }
+        .close-btn:hover {
+            background: #059669;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="success-icon">✓</div>
+        <h1>Connection Successful!</h1>
+        <p>Your account has been successfully connected. You can now close this window and return to your application.</p>
+        <button class="close-btn" onclick="window.close()">Close Window</button>
+    </div>
+    
+    <script>
+        // Auto-close after 3 seconds if window.close() doesn't work
+        setTimeout(() => {
+            try {
+                window.close();
+            } catch (e) {
+                // If close fails, show a message
+                document.querySelector('p').innerHTML = 'Connection successful! Please close this tab manually.';
+            }
+        }, 3000);
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- Added `/auth/success` and `/auth/failure` endpoints for Pipedream Connect OAuth redirects
- Created clean, minimal UI pages with proper success/failure messaging
- Users can now close the window instead of being redirected to asi.co.nz

## Changes Made

- **Success page** (`/auth/success`): Green checkmark, success message, auto-close after 3 seconds
- **Failure page** (`/auth/failure`): Red X, error message with retry button, auto-close after 5 seconds
- Embedded HTML directly in worker for simplicity
- Added route handlers to OAuth Provider configuration

## Usage

Set environment variables to use these endpoints:
```
CONNECT_SUCCESS_REDIRECT=https://your-worker-url/auth/success
CONNECT_ERROR_REDIRECT=https://your-worker-url/auth/failure
```

## Test Plan

- [ ] Deploy to staging environment
- [ ] Test Pipedream Connect OAuth flow with success case
- [ ] Test Pipedream Connect OAuth flow with failure case
- [ ] Verify pages display correctly and auto-close functionality works
- [ ] Verify manual close button works if auto-close fails

🤖 Generated with [Claude Code](https://claude.ai/code)